### PR TITLE
Added removeGroup() method to ShowMapper

### DIFF
--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -112,6 +112,47 @@ class ShowMapper extends BaseGroupedMapper
 
         return $this;
     }
+    
+    /**
+     * Removes a group.
+     *
+     * @param string $group          The group to delete
+     * @param string $tab            The tab the group belongs to, defaults to 'default'
+     * @param bool   $deleteEmptyTab Whether or not the Tab should be deleted, when the deleted group leaves the tab empty after deletion
+     *
+     * @return $this
+     */
+    public function removeGroup($group, $tab = 'default', $deleteEmptyTab = false)
+    {
+        $groups = $this->getGroups();
+
+        // When the default tab is used, the tabname is not prepended to the index in the group array
+        if ($tab !== 'default') {
+            $group = $tab.'.'.$group;
+        }
+
+        if (isset($groups[$group])) {
+            foreach ($groups[$group]['fields'] as $field) {
+                $this->remove($field);
+            }
+        }
+        unset($groups[$group]);
+
+        $tabs = $this->getTabs();
+        $key = array_search($group, $tabs[$tab]['groups']);
+
+        if (false !== $key) {
+            unset($tabs[$tab]['groups'][$key]);
+        }
+        if ($deleteEmptyTab && count($tabs[$tab]['groups']) == 0) {
+            unset($tabs[$tab]);
+        }
+
+        $this->setTabs($tabs);
+        $this->setGroups($groups);
+
+        return $this;
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because it's a new feature

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `ShowMapper::removeGroup()` method, similar to the one that exists in FormMapper
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note
## Subject

<!-- Describe your Pull Request content here -->

Add a removeGroup() method to the ShowMapper class, similar to FormMapper::removeGroup()
